### PR TITLE
SAGE: Early stopping and convergence checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 - Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, nosw used by `LOCO` and `LOCI`
   - Both get arugments `obs_loss = FALSE` and `aggregation_fun`, defaulting to `median` in case of `obs_loss = TRUE`, to allow for macro-averaged median of absolute differences calculcation as in original LOCO formulation, rather than the micro-averaged approach calculated by default.
 - Fix accidentally marginal `ConditionalSAGE`.
-- `SAGE` methods get convergence tracking if `early_stopping = TRUE`
+- `SAGE` methods get convergence tracking if `early_stopping = TRUE` ([#29](https://github.com/jemus42/xplainfi/pull/29))
   - Permutations are evaluated in steps of `check_interval` at a time, after each convergence is checked
   - If values change by less than `convergence_threshold`, convergence is assumed
   - A `$converged` field is set to `TRUE`

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,14 @@
 - Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, nosw used by `LOCO` and `LOCI`
   - Both get arugments `obs_loss = FALSE` and `aggregation_fun`, defaulting to `median` in case of `obs_loss = TRUE`, to allow for macro-averaged median of absolute differences calculcation as in original LOCO formulation, rather than the micro-averaged approach calculated by default.
 - Fix accidentally marginal `ConditionalSAGE`.
+- `SAGE` methods get convergence tracking if `early_stopping = TRUE`
+  - Permutations are evaluated in steps of `check_interval` at a time, after each convergence is checked
+  - If values change by less than `convergence_threshold`, convergence is assumed
+  - A `$converged` field is set to `TRUE`
+  - At least `min_permutations` are perfomed in any case, and `$n_permutations_used` shows the number of performed permutations
+  - `$convergence_history` tracks convergence history and can be analyzed to see per-feature values after each checkpoint
+  -  `$plot_convergence_history()` plots convergence history per feature
+  -  Convergence is tracked only for first resampling iteration
 
 # xplainfi 0.1.0
 

--- a/R/FeatureImportanceMeasure.R
+++ b/R/FeatureImportanceMeasure.R
@@ -52,7 +52,7 @@ FeatureImportanceMethod = R6Class(
           "regr" = mlr3::msr("regr.mse")
         )
         cli::cli_alert_info(
-          "No {.cls Measure} provided, using default measure {.val {self$measure$id}}"
+          "No {.cls Measure} provided, using {.code measure = msr({self$measure$id})}"
         )
       } else {
         self$measure = mlr3::assert_measure(measure, task = task, learner = learner)
@@ -64,9 +64,10 @@ FeatureImportanceMethod = R6Class(
       # resampling: default to holdout with default ratio if NULL
       if (is.null(resampling)) {
         resampling = mlr3::rsmp("holdout")$instantiate(task)
-        cli::cli_alert_info(
-          "No {.cls Resampling} provided, using holdout resampling with default ratio."
-        )
+        cli::cli_inform(c(
+          i = "No {.cls Resampling} provided",
+          "Using {.code resampling = rsmp(\"holdout\")} with default {.code ratio = {round(resampling$param_set$values$ratio, 2)}}."
+        ))
       }
       if (!resampling$is_instantiated) {
         resampling$instantiate(task)

--- a/R/FeatureImportanceMeasure.R
+++ b/R/FeatureImportanceMeasure.R
@@ -184,7 +184,21 @@ FeatureImportanceMethod = R6Class(
     #' @param ... Passed to `print()`
     print = function(...) {
       cli::cli_h2(self$label)
-      if (!is.null(self$importance)) print(self$importance, ...)
+      cli::cli_ul()
+      cli::cli_li("Feature{?s} of interest: {.val {self$features}}")
+      cli::cli_li("Parameters:")
+
+      pidx = seq_along(self$param_set$values)
+      sapply(pidx, \(i) {
+        cli::cli_ul("{.code {names(self$param_set$values)[i]}}: {.val {self$param_set$values[i]}}")
+      })
+
+      cli::cli_end()
+      if (!is.null(self$importance)) {
+        print(self$importance, ...)
+      } else {
+        cli::cli_inform("No importances computed yet.")
+      }
     }
   ),
   private = list(

--- a/R/SAGE.R
+++ b/R/SAGE.R
@@ -68,8 +68,8 @@ SAGE = R6Class(
       if (self$task$task_type == "classif") {
         if (learner$predict_type != "prob") {
           cli::cli_abort(c(
-            "Classification learners must use predict_type = 'prob' for SAGE.",
-            "i" = "Please set learner$predict_type = 'prob' before using SAGE."
+            "Classification learners require probability predictions for SAGE.",
+            "i" = "Please set {.code learner$configure(predict_type = \"prob\")} before using SAGE."
           ))
         }
       }

--- a/R/SAGE.R
+++ b/R/SAGE.R
@@ -223,6 +223,8 @@ SAGE = R6Class(
     #' @param features (`character` | `NULL`) Features to plot. If NULL, plots all features.
     #' @return A ggplot2 object
     plot_convergence = function(features = NULL) {
+      require_package("ggplot2")
+
       if (is.null(self$convergence_history)) {
         cli::cli_abort("No convergence history available. Run $compute() first.")
       }
@@ -233,8 +235,6 @@ SAGE = R6Class(
       if (!is.null(features)) {
         plot_data = plot_data[feature %in% features]
       }
-
-      require_package("ggplot2")
 
       p = ggplot2::ggplot(
         plot_data,
@@ -391,7 +391,7 @@ SAGE = R6Class(
 
         n_completed = n_completed + checkpoint_size
 
-        # Calculate current averages (careful with data.table reference semantics)
+        # Calculate current averages
         current_avg = sage_values / n_completed
 
         # Store convergence history (always, regardless of detect_convergence)
@@ -512,6 +512,11 @@ SAGE = R6Class(
           batch_data = combined_data[start_row:end_row]
 
           # Predict for this batch
+          if (xplain_opt("debug")) {
+            cli::cli_inform(
+              "Predicting on {.val {nrow(batch_data)}} instances in batch {.val {batch_idx}/{n_batches}}"
+            )
+          }
           pred_result = learner$predict_newdata(newdata = batch_data, task = self$task)
 
           # Store predictions
@@ -626,7 +631,7 @@ SAGE = R6Class(
       # Abstract method - must be implemented by subclasses
       cli::cli_abort(c(
         "Abstract method: {.fun marginalize_features} must be implemented by subclasses.",
-        "i" = "Use MarginalSAGE or ConditionalSAGE instead of the abstract SAGE class."
+        "i" = "Use {.cls MarginalSAGE} or {.cls ConditionalSAGE} instead of the abstract {.cls SAGE} class."
       ))
     }
   )

--- a/man/ConditionalSAGE.Rd
+++ b/man/ConditionalSAGE.Rd
@@ -40,6 +40,7 @@ sage$compute(batch_size = 1000)
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="compute"><a href='../../xplainfi/html/SAGE.html#method-SAGE-compute'><code>xplainfi::SAGE$compute()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="plot_convergence"><a href='../../xplainfi/html/SAGE.html#method-SAGE-plot_convergence'><code>xplainfi::SAGE$plot_convergence()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -58,7 +59,8 @@ Creates a new instance of the ConditionalSAGE class.
   n_permutations = 10L,
   reference_data = NULL,
   sampler = NULL,
-  max_reference_size = NULL
+  batch_size = 5000L,
+  max_reference_size = 100L
 )}\if{html}{\out{</div>}}
 }
 
@@ -72,6 +74,8 @@ Creates a new instance of the ConditionalSAGE class.
 \item{\code{reference_data}}{(data.table) Optional reference dataset.}
 
 \item{\code{sampler}}{(\link{ConditionalSampler}) Optional custom sampler. Defaults to ARFSampler.}
+
+\item{\code{batch_size}}{(\code{integer(1): 5000L}) Maximum number of observations to process in a single prediction call.}
 
 \item{\code{max_reference_size}}{(integer(1)) Maximum size of reference dataset.}
 }

--- a/man/MarginalSAGE.Rd
+++ b/man/MarginalSAGE.Rd
@@ -40,6 +40,7 @@ sage$compute(batch_size = 1000)
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="compute"><a href='../../xplainfi/html/SAGE.html#method-SAGE-compute'><code>xplainfi::SAGE$compute()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="plot_convergence"><a href='../../xplainfi/html/SAGE.html#method-SAGE-plot_convergence'><code>xplainfi::SAGE$plot_convergence()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -57,7 +58,8 @@ Creates a new instance of the MarginalSAGE class.
   features = NULL,
   n_permutations = 10L,
   reference_data = NULL,
-  max_reference_size = NULL
+  batch_size = 5000L,
+  max_reference_size = 100L
 )}\if{html}{\out{</div>}}
 }
 
@@ -69,6 +71,8 @@ Creates a new instance of the MarginalSAGE class.
 \item{\code{n_permutations}}{(integer(1)) Number of permutations to sample.}
 
 \item{\code{reference_data}}{(data.table) Optional reference dataset.}
+
+\item{\code{batch_size}}{(\code{integer(1): 5000L}) Maximum number of observations to process in a single prediction call.}
 
 \item{\code{max_reference_size}}{(integer(1)) Maximum size of reference dataset.}
 }

--- a/man/SAGE.Rd
+++ b/man/SAGE.Rd
@@ -31,6 +31,12 @@ In \emph{Advances in Neural Information Processing Systems}, volume 33, 17212--1
 \item{\code{reference_data}}{(data.table) Reference dataset for marginalization.}
 
 \item{\code{sampler}}{(\link{FeatureSampler}) Sampler object for marginalization.}
+
+\item{\code{convergence_history}}{(\link{data.table}) History of SAGE values during computation.}
+
+\item{\code{converged}}{(\code{logical(1)}) Whether convergence was detected.}
+
+\item{\code{n_permutations_used}}{(\code{integer(1)}) Actual number of permutations used.}
 }
 \if{html}{\out{</div>}}
 }
@@ -39,6 +45,7 @@ In \emph{Advances in Neural Information Processing Systems}, volume 33, 17212--1
 \itemize{
 \item \href{#method-SAGE-new}{\code{SAGE$new()}}
 \item \href{#method-SAGE-compute}{\code{SAGE$compute()}}
+\item \href{#method-SAGE-plot_convergence}{\code{SAGE$plot_convergence()}}
 \item \href{#method-SAGE-clone}{\code{SAGE$clone()}}
 }
 }
@@ -65,8 +72,9 @@ Creates a new instance of the SAGE class.
   features = NULL,
   n_permutations = 10L,
   reference_data = NULL,
+  batch_size = 5000L,
   sampler = NULL,
-  max_reference_size = NULL
+  max_reference_size = 100L
 )}\if{html}{\out{</div>}}
 }
 
@@ -75,13 +83,17 @@ Creates a new instance of the SAGE class.
 \describe{
 \item{\code{task, learner, measure, resampling, features}}{Passed to FeatureImportanceMethod.}
 
-\item{\code{n_permutations}}{(\code{integer(1)}) Number of permutations to sample for Shapley value estimation.}
+\item{\code{n_permutations}}{(\code{integer(1): 10L}) Number of permutations \emph{per coalition} to sample for Shapley value estimation.
+The total number of evaluated coalitions is \code{1 (empty) + n_permutations * n_features}.}
 
-\item{\code{reference_data}}{(\code{data.table | NULL}) Optional reference dataset. If \code{NULL}, uses training data.}
+\item{\code{reference_data}}{(\code{data.table | NULL}) Optional reference dataset. If \code{NULL}, uses training data.
+For each coalition to evaluate, an expanded datasets of size \code{n_test * n_reference} is created and evaluted in batches of \code{batch_size}.}
 
-\item{\code{sampler}}{(\link{FeatureSampler}) Sampler for marginalization.}
+\item{\code{batch_size}}{(\code{integer(1): 5000L}) Maximum number of observations to process in a single prediction call.}
 
-\item{\code{max_reference_size}}{(\code{integer(1) | NULL}) Maximum size of reference dataset. If reference is larger, it will be subsampled. If \code{NULL}, no subsampling is performed.}
+\item{\code{sampler}}{(\link{FeatureSampler}) Sampler for marginalization. Only relevant for \code{ConditionalSAGE}.}
+
+\item{\code{max_reference_size}}{(\code{integer(1): 100L}) Maximum size of reference dataset. If reference is larger, it will be subsampled.}
 }
 \if{html}{\out{</div>}}
 }
@@ -92,7 +104,14 @@ Creates a new instance of the SAGE class.
 \subsection{Method \code{compute()}}{
 Compute SAGE values.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{SAGE$compute(store_backends = TRUE, batch_size = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{SAGE$compute(
+  store_backends = TRUE,
+  batch_size = NULL,
+  detect_convergence = NULL,
+  convergence_threshold = NULL,
+  min_permutations = NULL,
+  check_interval = NULL
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
@@ -100,9 +119,37 @@ Compute SAGE values.
 \describe{
 \item{\code{store_backends}}{(logical(1)) Whether to store backends.}
 
-\item{\code{batch_size}}{(integer(1)) Maximum number of observations to process in a single prediction call. If NULL, processes all at once.}
+\item{\code{batch_size}}{(integer(1): 5000L) Maximum number of observations to process in a single prediction call.}
+
+\item{\code{detect_convergence}}{(logical(1)) Whether to check for convergence and stop early.}
+
+\item{\code{convergence_threshold}}{(numeric(1)) Relative change threshold for convergence detection.}
+
+\item{\code{min_permutations}}{(integer(1)) Minimum permutations before checking convergence.}
+
+\item{\code{check_interval}}{(integer(1)) Check convergence every N permutations.}
 }
 \if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-SAGE-plot_convergence"></a>}}
+\if{latex}{\out{\hypertarget{method-SAGE-plot_convergence}{}}}
+\subsection{Method \code{plot_convergence()}}{
+Plot convergence history of SAGE values.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{SAGE$plot_convergence(features = NULL)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{features}}{(\code{character} | \code{NULL}) Features to plot. If NULL, plots all features.}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+A ggplot2 object
 }
 }
 \if{html}{\out{<hr>}}

--- a/man/SAGE.Rd
+++ b/man/SAGE.Rd
@@ -107,7 +107,7 @@ Compute SAGE values.
 \if{html}{\out{<div class="r">}}\preformatted{SAGE$compute(
   store_backends = TRUE,
   batch_size = NULL,
-  detect_convergence = NULL,
+  early_stopping = NULL,
   convergence_threshold = NULL,
   min_permutations = NULL,
   check_interval = NULL
@@ -121,7 +121,7 @@ Compute SAGE values.
 
 \item{\code{batch_size}}{(integer(1): 5000L) Maximum number of observations to process in a single prediction call.}
 
-\item{\code{detect_convergence}}{(logical(1)) Whether to check for convergence and stop early.}
+\item{\code{early_stopping}}{(logical(1)) Whether to check for convergence and stop early.}
 
 \item{\code{convergence_threshold}}{(numeric(1)) Relative change threshold for convergence detection.}
 

--- a/tests/testthat/test-ConditionalSAGE.R
+++ b/tests/testthat/test-ConditionalSAGE.R
@@ -193,7 +193,7 @@ test_that("ConditionalSAGE requires predict_type='prob' for classification", {
       learner = learner,
       measure = measure
     ),
-    "Classification learners must use predict_type = 'prob' for SAGE"
+    "Classification learners require probability predictions for SAGE."
   )
 })
 

--- a/tests/testthat/test-ConditionalSAGE.R
+++ b/tests/testthat/test-ConditionalSAGE.R
@@ -303,23 +303,24 @@ test_that("ConditionalSAGE batching produces identical results", {
       sage$compute(batch_size = 10)
     })
 
-    # All results should be identical
+    # Results should be similar (but not identical due to ARF stochasticity)
+    # Use more reasonable tolerance for stochastic conditional sampling
     expect_equal(
       result_no_batch$importance,
       result_large_batch$importance,
-      tolerance = 1e-10,
+      tolerance = 0.05,
       info = paste("ConditionalSAGE", config$type, "- no batch vs large batch")
     )
     expect_equal(
       result_large_batch$importance,
       result_small_batch$importance,
-      tolerance = 1e-10,
+      tolerance = 0.05,
       info = paste("ConditionalSAGE", config$type, "- large batch vs small batch")
     )
     expect_equal(
       result_small_batch$importance,
       result_tiny_batch$importance,
-      tolerance = 1e-10,
+      tolerance = 0.05,
       info = paste("ConditionalSAGE", config$type, "- small batch vs tiny batch")
     )
   }

--- a/tests/testthat/test-MarginalSAGE.R
+++ b/tests/testthat/test-MarginalSAGE.R
@@ -363,7 +363,7 @@ test_that("MarginalSAGE requires predict_type='prob' for classification", {
       learner = learner,
       measure = measure
     ),
-    "Classification learners must use predict_type = 'prob' for SAGE"
+    "Classification learners require probability predictions for SAGE."
   )
 
   # Should work fine for regression

--- a/vignettes/articles/sage-methods.Rmd
+++ b/vignettes/articles/sage-methods.Rmd
@@ -110,7 +110,7 @@ marginal_results$feature = factor(
 
 # Color features by type (causal vs noise)
 marginal_results$feature_type = ifelse(
-  marginal_results$feature %in% c("x1", "x2", "x3"), 
+  marginal_results$feature %in% c("x1", "x3"), 
   "Causal", 
   "Noise"
 )
@@ -124,15 +124,16 @@ ggplot(marginal_results, aes(x = feature, y = importance)) +
   ) +
   labs(
     title = "Marginal SAGE Feature Importance",
-    subtitle = "Correlated features: x1 and x2 are highly correlated (r ≈ 0.999), x2 has no effect on y",
+    subtitle = "Correlated features: x1 and x2 are highly correlated (r ≈ 0.999)\nx2 has no effect on y",
     x = "Features", 
     y = "SAGE Value"
   ) +
   theme_minimal(base_size = 14) 
 ```
 
+We can also keep track of the SAGE value approximation across permutations:
 
-```{r}
+```{r convergance-marginal}
 marginal_sage$plot_convergence()
 ```
 
@@ -181,7 +182,7 @@ conditional_results$feature_type = ifelse(
 ggplot(conditional_results, aes(x = feature, y = importance)) +
   geom_col(aes(fill = feature_type), alpha = 0.8) +
   scale_fill_manual(
-    values = c("Causal" = "darkgreen", "Noise" = "lightcoral"),
+    values = c("Causal" = "steelblue", "Noise" = "lightcoral"),
     name = "Feature type"
   ) +
   labs(
@@ -192,6 +193,11 @@ ggplot(conditional_results, aes(x = feature, y = importance)) +
   ) +
   theme_minimal(base_size = 14) +
   theme(legend.position = "bottom")
+```
+
+
+```{r convergance-conditional}
+conditional_sage$plot_convergence()
 ```
 
 ## Comparison of Methods
@@ -218,7 +224,6 @@ ggplot(combined_results, aes(x = feature, y = importance, fill = method)) +
   scale_fill_manual(values = c("Marginal SAGE" = "steelblue", "Conditional SAGE" = "darkgreen")) +
   labs(
     title = "Marginal vs Conditional SAGE Comparison",
-    subtitle = "Key difference: How x1 and x2 (correlated features) are valued",
     x = "Features", 
     y = "SAGE Value",
     fill = "Method"

--- a/vignettes/articles/sage-methods.Rmd
+++ b/vignettes/articles/sage-methods.Rmd
@@ -52,7 +52,7 @@ where $\varepsilon \sim N(0, 0.2^2)$.
 
 ```{r data-setup}
 set.seed(123)
-task = sim_dgp_correlated(n = 800)
+task = sim_dgp_correlated(n = 1000)
 
 # Check the correlation structure
 task_data = task$data()
@@ -68,7 +68,7 @@ round(correlation_matrix, 3)
 Let's set up our learner and measure. We'll use a random forest and instantiate a resampling to ensure both methods see the same data:
 
 ```{r learner-setup}
-learner = lrn("regr.ranger", num.trees = 400)
+learner = lrn("regr.ranger")
 measure = msr("regr.mse")
 resampling = rsmp("holdout")
 resampling$instantiate(task)
@@ -86,11 +86,12 @@ marginal_sage = MarginalSAGE$new(
   measure = measure,
   resampling = resampling,
   n_permutations = 30L,  # More permutations for stable results
-  max_reference_size = 100L
+  max_reference_size = 100L,
+  batch_size = 5000L
 )
 
 # Compute SAGE values
-marginal_sage$compute(batch_size = 5000L)
+marginal_sage$compute()
 ```
 
 Let's visualize the results:
@@ -128,6 +129,11 @@ ggplot(marginal_results, aes(x = feature, y = importance)) +
     y = "SAGE Value"
   ) +
   theme_minimal(base_size = 14) 
+```
+
+
+```{r}
+marginal_sage$plot_convergence()
 ```
 
 ## Conditional SAGE


### PR DESCRIPTION
API for convergence tracking i snot great yet but it works, kind of. The early stopping bit is still in need of some improvement because I found it quite hard to have it stop, but in general I guess it works.

This now works by taking the number of permutations and creating a checkpoint after some number (default 5) of permutations after which convergence is checked and the current state of SAGE values is written to a history table. 
I realize this is now somewhat orthogonal to the `$score` table in the other method's implementations, where we also keep per-resampling, per-permutation importance scores, but in the case of SAGE I so far only ever used holdout due to the general slowness of things and the number of permutations here has a different meaning than the number of permutation iterations in `PFI`, for example.
Would be nice to unify the API and semantics a bit.

As for SAGE convergence, I wondered if the `max_reference_size` has a large impact on convergence but it looks like it's not huge. Here's `friedman1`'s first two features (both should have same contribution due to them being only an interaction effect) for `max_reference_size` $ \in  \{100, 500\}$ after 100 permutations each (quite a lot)

![image](https://github.com/user-attachments/assets/084ebc6c-8b26-4133-bfb4-1aa297d5c530)


In either case I'd argue that 50 permutations seems fine.

Here's the same for the most important feature (including intermediate reference size):

![image](https://github.com/user-attachments/assets/0a34d6c0-329e-4e91-8a07-8df8f042fd70)

Here it looks like a few more permutations wouldn't have hurt, but not sure what to conclude about the reference size here.

I should also note that computing SAGE for this task with `max_reference_size = 300` and `n_permutations = 100` took 7 hours or sousing the ranger learner with 5 threads.
It's just.. a lot of stuff to do. Maybe I need to parallelize batchwise predictions after all?
