### PR TITLE
WIP variance methods for `$importance()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ This turns out to be still a period of major changes in the early phase, so, uhm
 
 ## General changes and improvements
 
-- `$importance` become a function `$importance()` with arguments `standardize` and `variance_method`:
+- `$importance` become a function `$importance()` with arguments `standardize` and `variance_method` (#40):
   - `"nadeau_bengio"` implements the correction method by Nadeau & Bengio (2003) recommended by Molnaet et al. (2023).
 - Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, now used by `LOCO` and `LOCI`
   - Both get arugments `obs_loss = FALSE` use the measure's `$aggregator` for aggregation in case of `obs_loss = TRUE`, to allow for  median of absolute differences calculation as in original LOCO formulation, rather than the "micro-"averaged approach calculated by default.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,27 +2,42 @@
 
 This turns out to be still a period of major changes in the early phase, so, uhm, well.
 
-- Extend `ARFSampler` to store more arguments on construction, making it easier to "preconfigure" the sampler via arguments used in `$sample()`.
-- Standardize on `conditioning_set` as the name for the character vector defining features to condition on in `ConditionalSampler` and `RFI`.
-- Streamline and speedup `PerturbationImportance` implementation, also by using `learner$predict_newdata_fast()` (#39), bumping the mlr3 dependency >= 1.1.0.
-- Add `sim_dgp_ewald()` and other `sim_dgp_*()` helpers to simulate data (in `Task` form) with simple DGPs as used for illustration in Ewald et al. (2024) for example, which should make it easier to interpret the results of various importance methods.
-- Add `KnockoffSampler` (#16 via @mnwright)
-  - Currently does not support `conditioning_set`
+## General changes and improvements
+
+- `$importance` become a function `$importance()` with arguments `standardize` and `variance_method`:
+  - `"nadeau_bengio"` implements the correction method by Nadeau & Bengio (2003) recommended by Molnaet et al. (2023).
 - Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, now used by `LOCO` and `LOCI`
   - Both get arugments `obs_loss = FALSE` use the measure's `$aggregator` for aggregation in case of `obs_loss = TRUE`, to allow for  median of absolute differences calculation as in original LOCO formulation, rather than the "micro-"averaged approach calculated by default.
-- `SAGE`:
-  - Fix accidentally marginal `ConditionalSAGE`.
-  -  Also using `learner$predict_newdata_fast()` now
-  - `batch_size` controls number of observations used at once per `learner$predict_newdata_fast()` call (could lead to excessive RAM usage). 
-  - convergence tracking if `early_stopping = TRUE` ([#29](https://github.com/jemus42/xplainfi/pull/29))
-    - Permutations are evaluated in steps of `check_interval` at a time, after each convergence is checked
-    - If values change by less than `convergence_threshold`, convergence is assumed
-    - A `$converged` field is set to `TRUE`
-    - At least `min_permutations` are perfomed in any case, and `$n_permutations_used` shows the number of performed permutations
-    - `$convergence_history` tracks convergence history and can be analyzed to see per-feature values after each checkpoint
-    -  `$plot_convergence_history()` plots convergence history per feature
-    -  Convergence is tracked only for first resampling iteration
-    -  Also add standard error tracking as part of the convergence history ([#33](https://github.com/jemus42/xplainfi/pull/33))
+- Add `sim_dgp_ewald()` and other `sim_dgp_*()` helpers to simulate data (in `Task` form) with simple DGPs as used for illustration in Ewald et al. (2024) for example, which should make it easier to interpret the results of various importance methods.
+
+## Method-specific changes
+
+### `PerturbationImportance`
+
+- Streamline and speedup `PerturbationImportance` implementation, also by using `learner$predict_newdata_fast()` (#39), bumping the mlr3 dependency >= 1.1.0.
+
+### Conditional sampling
+
+- Extend `ARFSampler` to store more arguments on construction, making it easier to "preconfigure" the sampler via arguments used in `$sample()`.
+- Standardize on `conditioning_set` as the name for the character vector defining features to condition on in `ConditionalSampler` and `RFI`.
+- Add `KnockoffSampler` (#16 via @mnwright)
+  - Currently does not support `conditioning_set`
+  - Implementation is still incomplete
+
+### `SAGE`
+
+- Fix accidentally marginal `ConditionalSAGE`.
+-  Also using `learner$predict_newdata_fast()` now
+- `batch_size` controls number of observations used at once per `learner$predict_newdata_fast()` call (could lead to excessive RAM usage). 
+- convergence tracking if `early_stopping = TRUE` ([#29](https://github.com/jemus42/xplainfi/pull/29))
+  - Permutations are evaluated in steps of `check_interval` at a time, after each convergence is checked
+  - If values change by less than `convergence_threshold`, convergence is assumed
+  - A `$converged` field is set to `TRUE`
+  - At least `min_permutations` are perfomed in any case, and `$n_permutations_used` shows the number of performed permutations
+  - `$convergence_history` tracks convergence history and can be analyzed to see per-feature values after each checkpoint
+  -  `$plot_convergence_history()` plots convergence history per feature
+  -  Convergence is tracked only for first resampling iteration
+  -  Also add standard error tracking as part of the convergence history ([#33](https://github.com/jemus42/xplainfi/pull/33))
 
 
 # xplainfi 0.1.0

--- a/R/FeatureImportanceMeasure.R
+++ b/R/FeatureImportanceMeasure.R
@@ -176,9 +176,10 @@ FeatureImportanceMethod = R6Class(
     #' The stored [`measure`][mlr3::Measure] object's `aggregator` (default: `mean`) will be used to aggregated importance scores
     #' across resampling iterations and, depending on the method use, permutations ([PerturbationImportance] or refits [LOCO]).
     #' @param standardize (`logical(1)`: `FALSE`) If `TRUE`, importances are standardized by the highest score so all scores fall in `[-1, 1]`.
-    #' @param variance_method (`character(1)`: `"none"`) Variance method to use, defaulting to omitting variance estimation (`"none"`).
-    #'   If `"raw"`, uncorrected variance estimates are provided purely for informative purposes with **invalid** confidence intervals.
+    #' @param variance_method (`character(1)`: `"none"`) Variance estimation method to use, defaulting to omitting variance estimation (`"none"`).
+    #'   If `"raw"`, uncorrected variance estimates are provided purely for informative purposes with **invalid** (too narrow) confidence intervals.
     #'   If `"nadeau_bengio"`, variance correction is performed according to Nadeau & Bengio (2003) as suggested by Molnar et al. (2023).
+    #'   These methods are model-agnostic and rely on suitable `resampling`s, e.g. subsampling with 15 repeats for `"nadeau_bengio"`.
     #'   See details.
     #' @param conf_level (`numeric(1): 0.95`): Conficence level to use for confidence interval construction when `variance_method != "none"`.
     #'
@@ -209,6 +210,10 @@ FeatureImportanceMethod = R6Class(
     #'
     #' `iters_perm = 5` in this context only improves the stability of the PFI estimate within the resampling iteration, whereas `rsmp("subsampling", repeats = 15)`
     #' is used to accounter for learner variance and neccessitates variance correction factor.
+    #'
+    #' This appraoch can in principle also be applied to `CFI` and `RFI`, but beware that a conditional sample such as [ARFSampler] also needs to be trained on data,
+    #' which would need to be taken account by the variance estimation method.
+    #' Analogously, the `"nadeau_bengio"` correction was recommended for the use with [PFI] by Molnar et al., so it's use with [LOCO] or [MarginalSAGE] is experimental.
     #'
     #' Note that even if `measure` uses an `aggregator` function that is not the mean, variance estimation currently will always use [mean()] and [var()].
     #'

--- a/R/bibentries.R
+++ b/R/bibentries.R
@@ -151,5 +151,31 @@ bibentries = c(
     pages = "307",
     issn = "1471-2105",
     doi = "10.1186/1471-2105-9-307"
+  ),
+
+  molnar_2023 = bibentry(
+    "inproceedings",
+    title = "Relating the Partial Dependence Plot and Permutation Feature Importance to the Data Generating Process",
+    booktitle = "Explainable Artificial Intelligence",
+    author = "Molnar, Christoph and Freiesleben, Timo and K\u00f6nig, Gunnar and Herbinger, Julia and Reisinger, Tim and Casalicchio, Giuseppe and Wright, Marvin N. and Bischl, Bernd",
+    editor = "Longo, Luca",
+    year = "2023",
+    pages = "456--479",
+    publisher = "Springer Nature Switzerland",
+    doi = "10.1007/978-3-031-44064-9_24",
+    isbn = "978-3-031-44064-9"
+  ),
+
+  nadaeu_2003 = bibentry(
+    "article",
+    title = "Inference for the Generalization Error",
+    author = "Nadeau, Claude and Bengio, Yoshua",
+    year = "2003",
+    journal = "Machine Learning",
+    volume = "52",
+    number = "3",
+    pages = "239--281",
+    issn = "1573-0565",
+    doi = "10.1023/A:1024068626366"
   )
 )

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -8,9 +8,6 @@ Feature Importance Method Class
 
 Feature Importance Method Class
 }
-\note{
-Even if \code{measure} uses an \code{aggregator} function that is not the mean, variance estimation currently will always use \code{\link[stats:cor]{stats::var()}}.
-}
 \references{
 Nadeau, Claude, Bengio, Yoshua (2003).
 \dQuote{Inference for the Generalization Error.}
@@ -128,8 +125,8 @@ across resampling iterations and, depending on the method use, permutations (\li
 \item{\code{standardize}}{(\code{logical(1)}: \code{FALSE}) If \code{TRUE}, importances are standardized by the highest score so all scores fall in \verb{[-1, 1]}.}
 
 \item{\code{variance_method}}{(\code{character(1)}: \code{"none"}) Variance method to use, defaulting to omitting variance estimation (\code{"none"}).
-If \code{"raw"}, uncorrected (biased!) variance estimates are provided purely for informative purposes.
-If \code{"nadeau_bengio"}, variance correction is performed according to Nadeau & bengio (2003) as suggested by Molnar et al. (2023).
+If \code{"raw"}, uncorrected variance estimates are provided purely for informative purposes with \strong{invalid} confidence intervals.
+If \code{"nadeau_bengio"}, variance correction is performed according to Nadeau & Bengio (2003) as suggested by Molnar et al. (2023).
 See details.}
 
 \item{\code{conf_level}}{(\code{numeric(1): 0.95}): Conficence level to use for confidence interval construction when \code{variance_method != "none"}.}
@@ -139,11 +136,13 @@ See details.}
 \subsection{Details}{
 Variance estimates for importance scores are biased due to the resampling procedure. Molnar et al. (2023) suggest to use
 the variance correction factor proposed by Nadeau & Bengio (2003) of n2/n1, where n2 and n1 are the sizes of the test- and train set, respectively.
-This should then be combined with approx. 15 iterations of bootstrapping or subsampling. Note however that the use of bootstrapping in this
-context can lead to problematic information leakage when combined with learners that perform bootstrapping themselves, most famously Random Forest learners.
+This should then be combined with approx. 15 iterations of either bootstrapping or subsampling.
+
+The use of bootstrapping in this context can lead to problematic information leakage when combined with learners
+that perform bootstrapping themselves, e.g., Random Forest learners.
 In such cases, observations may be used as train- and test instances simultaneously, leading to erroneous performance estimates.
 
-A suggested approach leading to still imperfect, but improved variance estimates would be, for example:
+An approach leading to still imperfect, but improved variance estimates could be:
 
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{PFI$new(
   task = sim_dgp_interactions(n = 1000),
@@ -155,8 +154,10 @@ A suggested approach leading to still imperfect, but improved variance estimates
 )
 }\if{html}{\out{</div>}}
 
-Note that \code{iters_perm = 5} in this context only improves the stability of the PFI estimate within the resampling iteration, whereas \code{rsmp("subsampling", repeats = 15)}
+\code{iters_perm = 5} in this context only improves the stability of the PFI estimate within the resampling iteration, whereas \code{rsmp("subsampling", repeats = 15)}
 is used to accounter for learner variance and neccessitates variance correction factor.
+
+Note that even if \code{measure} uses an \code{aggregator} function that is not the mean, variance estimation currently will always use \code{\link[=mean]{mean()}} and \code{\link[=var]{var()}}.
 }
 
 \subsection{Returns}{

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -124,9 +124,10 @@ across resampling iterations and, depending on the method use, permutations (\li
 \describe{
 \item{\code{standardize}}{(\code{logical(1)}: \code{FALSE}) If \code{TRUE}, importances are standardized by the highest score so all scores fall in \verb{[-1, 1]}.}
 
-\item{\code{variance_method}}{(\code{character(1)}: \code{"none"}) Variance method to use, defaulting to omitting variance estimation (\code{"none"}).
-If \code{"raw"}, uncorrected variance estimates are provided purely for informative purposes with \strong{invalid} confidence intervals.
+\item{\code{variance_method}}{(\code{character(1)}: \code{"none"}) Variance estimation method to use, defaulting to omitting variance estimation (\code{"none"}).
+If \code{"raw"}, uncorrected variance estimates are provided purely for informative purposes with \strong{invalid} (too narrow) confidence intervals.
 If \code{"nadeau_bengio"}, variance correction is performed according to Nadeau & Bengio (2003) as suggested by Molnar et al. (2023).
+These methods are model-agnostic and rely on suitable \code{resampling}s, e.g. subsampling with 15 repeats for \code{"nadeau_bengio"}.
 See details.}
 
 \item{\code{conf_level}}{(\code{numeric(1): 0.95}): Conficence level to use for confidence interval construction when \code{variance_method != "none"}.}
@@ -156,6 +157,10 @@ An approach leading to still imperfect, but improved variance estimates could be
 
 \code{iters_perm = 5} in this context only improves the stability of the PFI estimate within the resampling iteration, whereas \code{rsmp("subsampling", repeats = 15)}
 is used to accounter for learner variance and neccessitates variance correction factor.
+
+This appraoch can in principle also be applied to \code{CFI} and \code{RFI}, but beware that a conditional sample such as \link{ARFSampler} also needs to be trained on data,
+which would need to be taken account by the variance estimation method.
+Analogously, the \code{"nadeau_bengio"} correction was recommended for the use with \link{PFI} by Molnar et al., so it's use with \link{LOCO} or \link{MarginalSAGE} is experimental.
 
 Note that even if \code{measure} uses an \code{aggregator} function that is not the mean, variance estimation currently will always use \code{\link[=mean]{mean()}} and \code{\link[=var]{var()}}.
 }

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -8,6 +8,19 @@ Feature Importance Method Class
 
 Feature Importance Method Class
 }
+\note{
+Even if \code{measure} uses an \code{aggregator} function that is not the mean, variance estimation currently will always use \code{\link[stats:cor]{stats::var()}}.
+}
+\references{
+Nadeau, Claude, Bengio, Yoshua (2003).
+\dQuote{Inference for the Generalization Error.}
+\emph{Machine Learning}, \bold{52}(3), 239--281.
+ISSN 1573-0565, \doi{10.1023/A:1024068626366}.
+Molnar, Christoph, Freiesleben, Timo, König, Gunnar, Herbinger, Julia, Reisinger, Tim, Casalicchio, Giuseppe, Wright, N. M, Bischl, Bernd (2023).
+\dQuote{Relating the Partial Dependence Plot and Permutation Feature Importance to the Data Generating Process.}
+In Longo, Luca (eds.), \emph{Explainable Artificial Intelligence}, 456--479.
+ISBN 978-3-031-44064-9, \doi{10.1007/978-3-031-44064-9_24}.
+}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -102,18 +115,53 @@ Get aggregated importance scores.
 The stored \code{\link[mlr3:Measure]{measure}} object's \code{aggregator} (default: \code{mean}) will be used to aggregated importance scores
 across resampling iterations and, depending on the method use, permutations (\link{PerturbationImportance} or refits \link{LOCO}).
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$importance(standardize = FALSE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$importance(
+  standardize = FALSE,
+  variance_method = c("none", "raw", "nadeau_bengio"),
+  conf_level = 0.95
+)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{standardize}}{(\code{logical(1)}: \code{FALSE}) If \code{TRUE}, importances are standardized by the highest score so all scores fall in \verb{[-1, 1]}.}
+
+\item{\code{variance_method}}{(\code{character(1)}: \code{"none"}) Variance method to use, defaulting to omitting variance estimation (\code{"none"}).
+If \code{"raw"}, uncorrected (biased!) variance estimates are provided purely for informative purposes.
+If \code{"nadeau_bengio"}, variance correction is performed according to Nadeau & bengio (2003) as suggested by Molnar et al. (2023).
+See details.}
+
+\item{\code{conf_level}}{(\code{numeric(1): 0.95}): Conficence level to use for confidence interval construction when \code{variance_method != "none"}.}
 }
 \if{html}{\out{</div>}}
 }
+\subsection{Details}{
+Variance estimates for importance scores are biased due to the resampling procedure. Molnar et al. (2023) suggest to use
+the variance correction factor proposed by Nadeau & Bengio (2003) of n2/n1, where n2 and n1 are the sizes of the test- and train set, respectively.
+This should then be combined with approx. 15 iterations of bootstrapping or subsampling. Note however that the use of bootstrapping in this
+context can lead to problematic information leakage when combined with learners that perform bootstrapping themselves, most famously Random Forest learners.
+In such cases, observations may be used as train- and test instances simultaneously, leading to erroneous performance estimates.
+
+A suggested approach leading to still imperfect, but improved variance estimates would be, for example:
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{PFI$new(
+  task = sim_dgp_interactions(n = 1000),
+  learner = lrn("regr.ranger", num.trees = 100),
+  measure = msr("regr.mse"),
+  # Subsampling instead of bootstrapping due to RF
+  resampling = rsmp("subsampling", repeats = 15),
+  iters_perm = 5
+)
+}\if{html}{\out{</div>}}
+
+Note that \code{iters_perm = 5} in this context only improves the stability of the PFI estimate within the resampling iteration, whereas \code{rsmp("subsampling", repeats = 15)}
+is used to accounter for learner variance and neccessitates variance correction factor.
+}
+
 \subsection{Returns}{
-(\link[data.table:data.table]{data.table}) Aggregated importance scores.
+(\link[data.table:data.table]{data.table}) Aggregated importance scores. with variables \verb{"feature", "importance"}
+and depending in \code{variance_method} also \verb{"var", "conf_lower", "conf_upper"}.
 }
 }
 \if{html}{\out{<hr>}}

--- a/tests/testthat/test-variance-estimation.R
+++ b/tests/testthat/test-variance-estimation.R
@@ -1,0 +1,150 @@
+test_that("importance() accepts all variance_method values", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 100)
+
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("subsampling", repeats = 5),
+    iters_perm = 2
+  )
+
+  pfi$compute()
+
+  # Test that all variance methods work
+  imp_none = pfi$importance(variance_method = "none")
+  imp_raw = pfi$importance(variance_method = "raw")
+  imp_nb = pfi$importance(variance_method = "nadeau_bengio")
+
+  expect_importance_dt(imp_none, features = pfi$features)
+  expect_importance_dt(imp_raw, features = pfi$features)
+  expect_importance_dt(imp_nb, features = pfi$features)
+})
+
+test_that("variance_method='none' produces no variance columns", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 100)
+
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("subsampling", repeats = 5),
+    iters_perm = 2
+  )
+
+  pfi$compute()
+  imp_none = pfi$importance(variance_method = "none")
+
+  # Check that only feature and importance columns exist
+  expect_equal(names(imp_none), c("feature", "importance"))
+})
+
+test_that("raw CIs are narrower than nadeau_bengio corrected CIs", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 200)
+
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("subsampling", repeats = 10, ratio = 0.8),
+    iters_perm = 5
+  )
+
+  pfi$compute()
+
+  imp_raw = pfi$importance(variance_method = "raw")
+  imp_nb = pfi$importance(variance_method = "nadeau_bengio")
+
+  # Calculate CI widths
+  width_raw = imp_raw$conf_upper - imp_raw$conf_lower
+  width_nb = imp_nb$conf_upper - imp_nb$conf_lower
+
+  # Raw CIs should be narrower than corrected ones on average
+  # Compare the mean widths instead of individual features
+  # The nadeau_bengio correction factor should make CIs wider on average
+  expect_true(mean(width_nb) > mean(width_raw))
+})
+
+test_that("nadeau_bengio correction requires appropriate resampling", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 100)
+
+  # Cross-validation is not supported for nadeau_bengio
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("cv", folds = 3),
+    iters_perm = 2
+  )
+
+  pfi$compute()
+
+  # Should error for unsupported resampling
+  expect_error(
+    pfi$importance(variance_method = "nadeau_bengio"),
+    regexp = "Must be a subset of"
+  )
+
+  # But raw variance should still work
+  imp_raw = pfi$importance(variance_method = "raw")
+  expect_importance_dt(imp_raw, features = pfi$features)
+})
+
+test_that("confidence level parameter works correctly", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 100)
+
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("subsampling", repeats = 5),
+    iters_perm = 2
+  )
+
+  pfi$compute()
+
+  # Test different confidence levels
+  imp_90 = pfi$importance(variance_method = "raw", conf_level = 0.90)
+  imp_95 = pfi$importance(variance_method = "raw", conf_level = 0.95)
+  imp_99 = pfi$importance(variance_method = "raw", conf_level = 0.99)
+
+  # Calculate CI widths
+  width_90 = imp_90$conf_upper - imp_90$conf_lower
+  width_95 = imp_95$conf_upper - imp_95$conf_lower
+  width_99 = imp_99$conf_upper - imp_99$conf_lower
+
+  # Higher confidence level should produce wider CIs (on average)
+  expect_true(mean(width_90) < mean(width_95))
+  expect_true(mean(width_95) < mean(width_99))
+})
+
+test_that("variance estimation works with bootstrap resampling", {
+  set.seed(123)
+  task = sim_dgp_independent(n = 100)
+
+  pfi = PFI$new(
+    task = task,
+    learner = mlr3::lrn("regr.rpart"),
+    measure = mlr3::msr("regr.mse"),
+    resampling = mlr3::rsmp("bootstrap", repeats = 5),
+    iters_perm = 2
+  )
+
+  pfi$compute()
+
+  # Both raw and nadeau_bengio should work with bootstrap
+  imp_raw = pfi$importance(variance_method = "raw")
+  imp_nb = pfi$importance(variance_method = "nadeau_bengio")
+
+  expect_importance_dt(imp_raw, features = pfi$features)
+  expect_importance_dt(imp_nb, features = pfi$features)
+
+  # Verify variance columns exist
+  expect_true(all(c("se", "conf_lower", "conf_upper") %in% names(imp_raw)))
+  expect_true(all(c("se", "conf_lower", "conf_upper") %in% names(imp_nb)))
+})

--- a/vignettes/articles/perturbation-importance.Rmd
+++ b/vignettes/articles/perturbation-importance.Rmd
@@ -847,6 +847,79 @@ In the baseline scenario with independent features:
 
 3. **Noise correctly identified**: All methods correctly assign near-zero importance to the noise features.
 
+## Variance Estimation and Confidence Intervals
+
+When using resampling, xplainfi can compute confidence intervals for importance scores to quantify uncertainty. However, standard variance calculations produce confidence intervals that are too narrow when observations appear in multiple resampling folds.
+
+### Example: Corrected vs Uncorrected Confidence Intervals
+
+```{r variance-estimation}
+#| cache: true
+# Demonstrate variance correction with subsampling
+task_var <- sim_dgp_independent(n = 300)
+
+pfi_var <- PFI$new(
+  task = task_var,
+  learner = lrn("regr.ranger", num.trees = 100),
+  measure = msr("regr.mse"),
+  resampling = rsmp("subsampling", repeats = 10, ratio = 0.8),
+  iters_perm = 5
+)
+
+pfi_var$compute()
+
+# Compare variance methods
+imp_raw <- pfi_var$importance(variance_method = "raw") # Uncorrected (too narrow!)
+imp_corrected <- pfi_var$importance(variance_method = "nadeau_bengio") # Corrected
+
+# Show the difference for important features
+imp_raw[grepl("^important", feature), .(feature, importance, conf_lower, conf_upper)]
+imp_corrected[grepl("^important", feature), .(feature, importance, conf_lower, conf_upper)]
+```
+
+```{r variance-comparison-plot}
+#| echo: false
+#| fig.width: 8
+#| fig.height: 5
+# Visualize the difference
+var_comparison <- rbindlist(list(
+  imp_raw[
+    grepl("^important", feature),
+    .(feature, importance, conf_lower, conf_upper, method = "Uncorrected (too narrow!)")
+  ],
+  imp_corrected[
+    grepl("^important", feature),
+    .(feature, importance, conf_lower, conf_upper, method = "Corrected (Nadeau-Bengio)")
+  ]
+))
+
+ggplot(var_comparison, aes(x = feature, y = importance, color = method)) +
+  geom_point(position = position_dodge(width = 0.3), size = 2) +
+  geom_errorbar(
+    aes(ymin = conf_lower, ymax = conf_upper),
+    position = position_dodge(width = 0.3),
+    width = 0.15
+  ) +
+  scale_color_manual(
+    values = c("Uncorrected (too narrow!)" = "red", "Corrected (Nadeau-Bengio)" = "blue")
+  ) +
+  labs(
+    title = "Corrected vs Uncorrected Confidence Intervals",
+    subtitle = "Nadeau-Bengio correction provides honest uncertainty estimates",
+    y = "Importance Score",
+    x = NULL,
+    color = NULL
+  ) +
+  theme_minimal() +
+  theme(legend.position = "top")
+```
+
+### Practical Recommendations
+
+- Use `variance_method = "nadeau_bengio"` when using bootstrap or subsampling for improved (yet still flawed) confidence intervals
+- The default `variance_method = "none"` returns only point estimates without uncertainty
+- Never use `variance_method = "raw"` for actual results, the uncorrected intervals are misleadingly narrow
+
 ## Key Takeaways
 
 Through these four scenarios, we've demonstrated:


### PR DESCRIPTION
`$importance()` at least aggregates importance scores using the `measure`'s `aggregator`, e.g. `mean`.

Addtionally now, depending on argument `variance_method`:

- `none`: Current behavior, no variance estimation
- `raw`: Raw, uncorrected variances across all resamplings, refits, etc.
- `nadeau_bengio`: Following the recommendation from Molnar et al. (2023) to use the `1/m + (n2/n1)` correction factor. Only allowed for bootstrap / subsampling.

Since `$importance()` is (at least for now) general for all feature importance methods, this applies to `PFI` the same way it does to `CFI` or `MarginalSAGE` etc. and probably needs a few big warning labels to make it clear that it may or may not be reasonable to use with anything that isn't PFI.