### PR TITLE
`obs_loss` handling for PerturbationImportance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,13 +4,26 @@ This turns out to be still a period of major changes in the early phase, so, uhm
 
 ## General changes and improvements
 
-- `$importance` become a function `$importance()` with arguments `standardize` and `variance_method` (#40):
+- `$importance` becomes a function `$importance()` with arguments `standardize` and `variance_method` (#40):
   - `"nadeau_bengio"` implements the correction method by Nadeau & Bengio (2003) recommended by Molnaet et al. (2023).
-- Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, now used by `LOCO` and `LOCI`
-  - Both get arugments `obs_loss = FALSE` use the measure's `$aggregator` for aggregation in case of `obs_loss = TRUE`, to allow for  median of absolute differences calculation as in original LOCO formulation, rather than the "micro-"averaged approach calculated by default.
+
 - Add `sim_dgp_ewald()` and other `sim_dgp_*()` helpers to simulate data (in `Task` form) with simple DGPs as used for illustration in Ewald et al. (2024) for example, which should make it easier to interpret the results of various importance methods.
 
+### Observation-wise losses
+
+- `$scores` becomes `$scores()` and re-computes iteration-wise scores depending on `relation` on the fly. Original scores are stored in `$.scores` (for now)
+-  `$obs_scores()` analogously computes observation-wise importance scores base on losses stored in `$.obs_losses` **if** `measure` has a `Measure$obs_loss()`
+
+- `$predictions` will probably be removed again?
+
 ## Method-specific changes
+
+### `LeaveOutIn`
+
+This is in flux and will be changed again
+
+- Add `$obs_loss` and `$predictions` fields to `FeatureImportanceMeasure`, now used by `LOCO` and `LOCI`
+  - Both get arugments `obs_loss = FALSE` use the measure's `$aggregator` for aggregation in case of `obs_loss = TRUE`, to allow for  median of absolute differences calculation as in original LOCO formulation, rather than the "micro-"averaged approach calculated by default.
 
 ### `PerturbationImportance`
 
@@ -27,7 +40,7 @@ This turns out to be still a period of major changes in the early phase, so, uhm
 ### `SAGE`
 
 - Fix accidentally marginal `ConditionalSAGE`.
--  Also using `learner$predict_newdata_fast()` now
+- Also using `learner$predict_newdata_fast()` now  (#39)
 - `batch_size` controls number of observations used at once per `learner$predict_newdata_fast()` call (could lead to excessive RAM usage). 
 - convergence tracking if `early_stopping = TRUE` ([#29](https://github.com/jemus42/xplainfi/pull/29))
   - Permutations are evaluated in steps of `check_interval` at a time, after each convergence is checked

--- a/R/FeatureImportanceMeasure.R
+++ b/R/FeatureImportanceMeasure.R
@@ -246,7 +246,7 @@ FeatureImportanceMethod = R6Class(
 			setnames(
 				obs_loss_baseline,
 				old = c("iteration", self$measure$id),
-				new = c("iter_rsmp", "baseline_loss")
+				new = c("iter_rsmp", "loss_baseline")
 			)
 
 			obs_loss_combined = obs_loss_baseline[
@@ -257,7 +257,7 @@ FeatureImportanceMethod = R6Class(
 
 			obs_loss_combined[,
 				obs_importance := private$.compute_score(
-					baseline_loss,
+					loss_baseline,
 					loss_perturbed,
 					relation = relation,
 					minimize = self$measure$minimize
@@ -272,7 +272,7 @@ FeatureImportanceMethod = R6Class(
 				"iter_perm",
 				"iter_refit",
 				"row_ids",
-				"baseline_loss",
+				"loss_baseline",
 				"loss_perturbed",
 				"obs_importance"
 			)

--- a/R/PerturbationImportance.R
+++ b/R/PerturbationImportance.R
@@ -221,6 +221,7 @@ PerturbationImportance = R6Class(
 #'   iters_perm = 3
 #' )
 #' pfi$compute()
+#' pfi$importance()
 #' @export
 PFI = R6Class(
 	"PFI",
@@ -289,6 +290,7 @@ PFI = R6Class(
 #'   measure = msr("classif.ce")
 #' )
 #' cfi$compute()
+#' cfi$importance()
 #' @export
 CFI = R6Class(
 	"CFI",
@@ -367,6 +369,7 @@ CFI = R6Class(
 #'   conditioning_set = c("important1")
 #' )
 #' rfi$compute()
+#' rfi$importance()
 #' @export
 RFI = R6Class(
 	"RFI",

--- a/R/PerturbationImportance.R
+++ b/R/PerturbationImportance.R
@@ -90,7 +90,6 @@ PerturbationImportance = R6Class(
 					.envir = .progress_env
 				)
 			}
-			# browser()
 			# Get predictions for each resampling iter, permutation iter, feature
 			all_preds = data.table::rbindlist(
 				lapply(seq_len(self$resampling$iters), \(iter) {
@@ -165,7 +164,6 @@ PerturbationImportance = R6Class(
 
 			# for obs_loss:
 			# Not all losses are decomposable so this is optional and depends on the provided measure
-			# browser()
 			if (!is.null(self$measure$obs_loss)) {
 				obs_loss_all <- all_preds[,
 					{
@@ -260,10 +258,11 @@ PFI = R6Class(
 
 		#' @description
 		#' Compute PFI scores
-		#' @param relation (character(1)) How to relate perturbed scores to originals. If `NULL`, uses stored value.
 		#' @param iters_perm (integer(1)) Number of permutation iterations. If `NULL`, uses stored value.
-		#' @param store_backends (logical(1)) Whether to store backends
-		compute = function(relation = NULL, iters_perm = NULL, store_backends = TRUE) {
+		#' @param store_backends (logical(1)) Whether to store backends, passed to [mlr3::resample()] internally
+		#' for the initial fit of the learner.
+		#' This may be required for certain measures and is recommended to leave enabled unless really necessary.
+		compute = function(iters_perm = NULL, store_backends = TRUE) {
 			# PFI uses the MarginalSampler directly
 			private$.compute_perturbation_importance(
 				iters_perm = iters_perm,
@@ -335,15 +334,14 @@ CFI = R6Class(
 
 		#' @description
 		#' Compute CFI scores
-		#' @param relation (character(1)) How to relate perturbed scores to originals. If `NULL`, uses stored value.
 		#' @param iters_perm (integer(1)) Number of permutation iterations. If `NULL`, uses stored value.
-		#' @param store_backends (logical(1)) Whether to store backends
-		compute = function(relation = NULL, iters_perm = NULL, store_backends = TRUE) {
+		#' @param store_backends (logical(1)) Whether to store backends, passed to [mlr3::resample()] internally
+		#' for the initial fit of the learner.
+		#' This may be required for certain measures and is recommended to leave enabled unless really necessary.
+		compute = function(iters_perm = NULL, store_backends = TRUE) {
 			# CFI expects sampler configured to condition on all other features for each feature
 			# Default for ARFSampler
-			# TODO: Needs more rigorous approach
 			private$.compute_perturbation_importance(
-				relation = relation,
 				iters_perm = iters_perm,
 				store_backends = store_backends,
 				sampler = self$sampler
@@ -445,12 +443,12 @@ RFI = R6Class(
 
 		#' @description
 		#' Compute RFI scores
-		#' @param relation (character(1)) How to relate perturbed scores to originals. If `NULL`, uses stored value.
-		#' @param conditioning_set ([character()]) Set of features to condition on. If `NULL`, uses the stored parameter value.
+		#' @param conditioning_set (character()) Set of features to condition on. If `NULL`, uses the stored parameter value.
 		#' @param iters_perm (integer(1)) Number of permutation iterations. If `NULL`, uses stored value.
-		#' @param store_backends (logical(1)) Whether to store backends
+		#' @param store_backends (logical(1)) Whether to store backends, passed to [mlr3::resample()] internally
+		#' for the initial fit of the learner.
+		#' This may be required for certain measures and is recommended to leave enabled unless really necessary.
 		compute = function(
-			relation = NULL,
 			conditioning_set = NULL,
 			iters_perm = NULL,
 			store_backends = TRUE
@@ -469,7 +467,6 @@ RFI = R6Class(
 
 			# Use the (potentially modified) sampler
 			private$.compute_perturbation_importance(
-				relation = relation,
 				iters_perm = iters_perm,
 				store_backends = store_backends,
 				sampler = self$sampler

--- a/R/PerturbationImportance.R
+++ b/R/PerturbationImportance.R
@@ -377,7 +377,7 @@ RFI = R6Class(
 		#' @param task,learner,measure,resampling,features Passed to PerturbationImportance
 		#' @param conditioning_set ([character()]) Set of features to condition on. Can be overridden in `$compute()`.
 		#'   Default (`character(0)`) is equivalent to `PFI`. In `CFI`, this would be set to all features except tat of interest.
-		#' @param relation (character(1)) How to relate perturbed scores to originals. Can be overridden in `$compute()`.
+		#' @param relation (character(1)) How to relate perturbed scores to originals. Can be overridden in `$scores()`.
 		#' @param iters_perm (integer(1)) Number of permutation iterations. Can be overridden in `$compute()`.
 		#' @param sampler ([ConditionalSampler]) Optional custom sampler. Defaults to ARFSampler
 		initialize = function(
@@ -387,6 +387,7 @@ RFI = R6Class(
 			resampling = NULL,
 			features = NULL,
 			conditioning_set = NULL,
+			relation = "difference",
 			iters_perm = 1L,
 			sampler = NULL
 		) {

--- a/man/CFI.Rd
+++ b/man/CFI.Rd
@@ -16,6 +16,7 @@ cfi = CFI$new(
   measure = msr("classif.ce")
 )
 cfi$compute()
+cfi$importance()
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/CFI.Rd
+++ b/man/CFI.Rd
@@ -39,8 +39,10 @@ Blesch, Kristin, Koenen, Niklas, Kapar, Jan, Golchian, Pegah, Burk, Lukas, Loech
 <details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/CFI.Rd
+++ b/man/CFI.Rd
@@ -84,17 +84,17 @@ Creates a new instance of the CFI class
 \subsection{Method \code{compute()}}{
 Compute CFI scores
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{CFI$compute(relation = NULL, iters_perm = NULL, store_backends = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{CFI$compute(iters_perm = NULL, store_backends = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. If \code{NULL}, uses stored value.}
-
 \item{\code{iters_perm}}{(integer(1)) Number of permutation iterations. If \code{NULL}, uses stored value.}
 
-\item{\code{store_backends}}{(logical(1)) Whether to store backends}
+\item{\code{store_backends}}{(logical(1)) Whether to store backends, passed to \code{\link[mlr3:resample]{mlr3::resample()}} internally
+for the initial fit of the learner.
+This may be required for certain measures and is recommended to leave enabled unless really necessary.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/ConditionalSAGE.Rd
+++ b/man/ConditionalSAGE.Rd
@@ -37,11 +37,13 @@ sage$compute(batch_size = 1000)
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="compute"><a href='../../xplainfi/html/SAGE.html#method-SAGE-compute'><code>xplainfi::SAGE$compute()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="plot_convergence"><a href='../../xplainfi/html/SAGE.html#method-SAGE-plot_convergence'><code>xplainfi::SAGE$plot_convergence()</code></a></span></li>
 </ul>

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -29,17 +29,13 @@ ISBN 978-3-031-44064-9, \doi{10.1007/978-3-031-44064-9_24}.
 
 \item{\code{measure}}{(\link[mlr3:Measure]{mlr3::Measure})}
 
-\item{\code{resampling}}{(\link[mlr3:Resampling]{mlr3::Resampling})}
+\item{\code{resampling}}{(\link[mlr3:Resampling]{mlr3::Resampling}), instantiated upon construction.}
 
-\item{\code{resample_result}}{(\link[mlr3:ResampleResult]{mlr3::ResampleResult})}
+\item{\code{resample_result}}{(\link[mlr3:ResampleResult]{mlr3::ResampleResult}) of the original \code{learner} and \code{task}, used for baseline scores.}
 
 \item{\code{features}}{(\code{character})}
 
 \item{\code{param_set}}{(\code{\link[paradox:ps]{paradox::ps()}})}
-
-\item{\code{scores}}{(\link[data.table:data.table]{data.table}) Individual performance scores used to compute \verb{$importance()} per resampling iteration and permutation iteration.}
-
-\item{\code{obs_losses}}{(\link[data.table:data.table]{data.table}) Observation-wise losses when available (e.g., when using obs_loss = TRUE). Contains columns for row_ids, feature, iteration indices, individual loss values, and both reference and feature-specific predictions.}
 
 \item{\code{predictions}}{(\link[data.table:data.table]{data.table}) Feature-specific prediction objects when using obs_loss = TRUE. Contains columns for feature, iteration, iter_refit, and prediction objects. Similar to ResampleResult$predictions() but extended for feature-specific models.}
 }
@@ -51,8 +47,10 @@ ISBN 978-3-031-44064-9, \doi{10.1007/978-3-031-44064-9_24}.
 \item \href{#method-FeatureImportanceMethod-new}{\code{FeatureImportanceMethod$new()}}
 \item \href{#method-FeatureImportanceMethod-compute}{\code{FeatureImportanceMethod$compute()}}
 \item \href{#method-FeatureImportanceMethod-importance}{\code{FeatureImportanceMethod$importance()}}
+\item \href{#method-FeatureImportanceMethod-obs_scores}{\code{FeatureImportanceMethod$obs_scores()}}
 \item \href{#method-FeatureImportanceMethod-reset}{\code{FeatureImportanceMethod$reset()}}
 \item \href{#method-FeatureImportanceMethod-print}{\code{FeatureImportanceMethod$print()}}
+\item \href{#method-FeatureImportanceMethod-scores}{\code{FeatureImportanceMethod$scores()}}
 \item \href{#method-FeatureImportanceMethod-clone}{\code{FeatureImportanceMethod$clone()}}
 }
 }
@@ -88,17 +86,12 @@ This is typically intended for use by derived classes.
 \subsection{Method \code{compute()}}{
 Compute feature importance scores
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$compute(
-  relation = c("difference", "ratio"),
-  store_backends = TRUE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$compute(store_backends = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{relation}}{(\code{character(1): "difference"}) How to relate perturbed scores to originals ("difference" or "ratio")}
-
 \item{\code{store_backends}}{(\code{logical(1): TRUE}) Whether to store backends.}
 }
 \if{html}{\out{</div>}}
@@ -171,6 +164,20 @@ and depending in \code{variance_method} also \verb{"var", "conf_lower", "conf_up
 }
 }
 \if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-FeatureImportanceMethod-obs_scores"></a>}}
+\if{latex}{\out{\hypertarget{method-FeatureImportanceMethod-obs_scores}{}}}
+\subsection{Method \code{obs_scores()}}{
+Calculate observation-wise importance scores.
+
+Requires that \verb{$compute()} was run and that \code{measure} is decomposable and
+has an observation-wise loss (\code{Measure$obs_loss()}) associated with it.
+This is not the case for measure like \code{classif.auc}, which is not decomposable.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$obs_scores()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FeatureImportanceMethod-reset"></a>}}
 \if{latex}{\out{\hypertarget{method-FeatureImportanceMethod-reset}{}}}
 \subsection{Method \code{reset()}}{
@@ -196,6 +203,20 @@ Print importance scores
 }
 \if{html}{\out{</div>}}
 }
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-FeatureImportanceMethod-scores"></a>}}
+\if{latex}{\out{\hypertarget{method-FeatureImportanceMethod-scores}{}}}
+\subsection{Method \code{scores()}}{
+Calculate importance scores for each resampling iteration and sub-iterations
+(\code{iter_rsmp} in \link{PFI} for example).
+
+Iteration-wise importance are computed on the fly depending on the chosen relation
+(\code{difference} or \code{ratio}) to avoid re-computation if only a different relation is needed.
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$scores()}\if{html}{\out{</div>}}
+}
+
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FeatureImportanceMethod-clone"></a>}}

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -106,6 +106,7 @@ The stored \code{\link[mlr3:Measure]{measure}} object's \code{aggregator} (defau
 across resampling iterations and, depending on the method use, permutations (\link{PerturbationImportance} or refits \link{LOCO}).
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$importance(
+  relation = NULL,
   standardize = FALSE,
   variance_method = c("none", "raw", "nadeau_bengio"),
   conf_level = 0.95
@@ -115,6 +116,8 @@ across resampling iterations and, depending on the method use, permutations (\li
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
+\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals ("difference" or "ratio"). If \code{NULL}, uses stored parameter value.}
+
 \item{\code{standardize}}{(\code{logical(1)}: \code{FALSE}) If \code{TRUE}, importances are standardized by the highest score so all scores fall in \verb{[-1, 1]}.}
 
 \item{\code{variance_method}}{(\code{character(1)}: \code{"none"}) Variance estimation method to use, defaulting to omitting variance estimation (\code{"none"}).
@@ -173,9 +176,16 @@ Requires that \verb{$compute()} was run and that \code{measure} is decomposable 
 has an observation-wise loss (\code{Measure$obs_loss()}) associated with it.
 This is not the case for measure like \code{classif.auc}, which is not decomposable.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$obs_scores()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$obs_scores(relation = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals ("difference" or "ratio"). If \code{NULL}, uses stored parameter value.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FeatureImportanceMethod-reset"></a>}}
@@ -214,9 +224,16 @@ Calculate importance scores for each resampling iteration and sub-iterations
 Iteration-wise importance are computed on the fly depending on the chosen relation
 (\code{difference} or \code{ratio}) to avoid re-computation if only a different relation is needed.
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$scores()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{FeatureImportanceMethod$scores(relation = NULL)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals ("difference" or "ratio"). If \code{NULL}, uses stored parameter value.}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-FeatureImportanceMethod-clone"></a>}}

--- a/man/LOCI.Rd
+++ b/man/LOCI.Rd
@@ -62,11 +62,13 @@ loci_median$compute()
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="LeaveOutIn" data-id="compute"><a href='../../xplainfi/html/LeaveOutIn.html#method-LeaveOutIn-compute'><code>xplainfi::LeaveOutIn$compute()</code></a></span></li>
 </ul>
 </details>

--- a/man/LOCO.Rd
+++ b/man/LOCO.Rd
@@ -64,11 +64,13 @@ ISSN 0162-1459, \doi{10.1080/01621459.2017.1307116}.
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="LeaveOutIn" data-id="compute"><a href='../../xplainfi/html/LeaveOutIn.html#method-LeaveOutIn-compute'><code>xplainfi::LeaveOutIn$compute()</code></a></span></li>
 </ul>
 </details>

--- a/man/LeaveOutIn.Rd
+++ b/man/LeaveOutIn.Rd
@@ -30,8 +30,10 @@ This is an abstract class - use LOCO or LOCI.
 <details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/MarginalSAGE.Rd
+++ b/man/MarginalSAGE.Rd
@@ -37,11 +37,13 @@ sage$compute(batch_size = 1000)
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="compute"><a href='../../xplainfi/html/SAGE.html#method-SAGE-compute'><code>xplainfi::SAGE$compute()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="SAGE" data-id="plot_convergence"><a href='../../xplainfi/html/SAGE.html#method-SAGE-plot_convergence'><code>xplainfi::SAGE$plot_convergence()</code></a></span></li>
 </ul>

--- a/man/PFI.Rd
+++ b/man/PFI.Rd
@@ -31,6 +31,7 @@ pfi = PFI$new(
   iters_perm = 3
 )
 pfi$compute()
+pfi$importance()
 \dontshow{\}) # examplesIf}
 }
 \references{

--- a/man/PFI.Rd
+++ b/man/PFI.Rd
@@ -62,8 +62,10 @@ ISSN 1471-2105, \doi{10.1186/1471-2105-9-307}.
 <details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/PFI.Rd
+++ b/man/PFI.Rd
@@ -104,17 +104,17 @@ Creates a new instance of the PFI class
 \subsection{Method \code{compute()}}{
 Compute PFI scores
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{PFI$compute(relation = NULL, iters_perm = NULL, store_backends = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{PFI$compute(iters_perm = NULL, store_backends = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. If \code{NULL}, uses stored value.}
-
 \item{\code{iters_perm}}{(integer(1)) Number of permutation iterations. If \code{NULL}, uses stored value.}
 
-\item{\code{store_backends}}{(logical(1)) Whether to store backends}
+\item{\code{store_backends}}{(logical(1)) Whether to store backends, passed to \code{\link[mlr3:resample]{mlr3::resample()}} internally
+for the initial fit of the learner.
+This may be required for certain measures and is recommended to leave enabled unless really necessary.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/PerturbationImportance.Rd
+++ b/man/PerturbationImportance.Rd
@@ -24,12 +24,14 @@ Abstract base class for perturbation-based importance methods PFI, CFI, and RFI
 }
 }
 \if{html}{\out{
-<details open><summary>Inherited methods</summary>
+<details><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="compute"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-compute'><code>xplainfi::FeatureImportanceMethod$compute()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/man/RFI.Rd
+++ b/man/RFI.Rd
@@ -17,6 +17,7 @@ rfi = RFI$new(
   conditioning_set = c("important1")
 )
 rfi$compute()
+rfi$importance()
 \dontshow{\}) # examplesIf}
 }
 \references{
@@ -60,6 +61,7 @@ Creates a new instance of the RFI class
   resampling = NULL,
   features = NULL,
   conditioning_set = NULL,
+  relation = "difference",
   iters_perm = 1L,
   sampler = NULL
 )}\if{html}{\out{</div>}}
@@ -73,11 +75,11 @@ Creates a new instance of the RFI class
 \item{\code{conditioning_set}}{(\code{\link[=character]{character()}}) Set of features to condition on. Can be overridden in \verb{$compute()}.
 Default (\code{character(0)}) is equivalent to \code{PFI}. In \code{CFI}, this would be set to all features except tat of interest.}
 
+\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. Can be overridden in \verb{$scores()}.}
+
 \item{\code{iters_perm}}{(integer(1)) Number of permutation iterations. Can be overridden in \verb{$compute()}.}
 
 \item{\code{sampler}}{(\link{ConditionalSampler}) Optional custom sampler. Defaults to ARFSampler}
-
-\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. Can be overridden in \verb{$compute()}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/RFI.Rd
+++ b/man/RFI.Rd
@@ -40,8 +40,10 @@ In \emph{2020 25th International Conference on Pattern Recognition (ICPR)}, 9318
 <details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}
@@ -58,7 +60,6 @@ Creates a new instance of the RFI class
   resampling = NULL,
   features = NULL,
   conditioning_set = NULL,
-  relation = "difference",
   iters_perm = 1L,
   sampler = NULL
 )}\if{html}{\out{</div>}}
@@ -72,11 +73,11 @@ Creates a new instance of the RFI class
 \item{\code{conditioning_set}}{(\code{\link[=character]{character()}}) Set of features to condition on. Can be overridden in \verb{$compute()}.
 Default (\code{character(0)}) is equivalent to \code{PFI}. In \code{CFI}, this would be set to all features except tat of interest.}
 
-\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. Can be overridden in \verb{$compute()}.}
-
 \item{\code{iters_perm}}{(integer(1)) Number of permutation iterations. Can be overridden in \verb{$compute()}.}
 
 \item{\code{sampler}}{(\link{ConditionalSampler}) Optional custom sampler. Defaults to ARFSampler}
+
+\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. Can be overridden in \verb{$compute()}.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/RFI.Rd
+++ b/man/RFI.Rd
@@ -88,24 +88,19 @@ Default (\code{character(0)}) is equivalent to \code{PFI}. In \code{CFI}, this w
 \subsection{Method \code{compute()}}{
 Compute RFI scores
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{RFI$compute(
-  relation = NULL,
-  conditioning_set = NULL,
-  iters_perm = NULL,
-  store_backends = TRUE
-)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{RFI$compute(conditioning_set = NULL, iters_perm = NULL, store_backends = TRUE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
-\item{\code{relation}}{(character(1)) How to relate perturbed scores to originals. If \code{NULL}, uses stored value.}
-
-\item{\code{conditioning_set}}{(\code{\link[=character]{character()}}) Set of features to condition on. If \code{NULL}, uses the stored parameter value.}
+\item{\code{conditioning_set}}{(character()) Set of features to condition on. If \code{NULL}, uses the stored parameter value.}
 
 \item{\code{iters_perm}}{(integer(1)) Number of permutation iterations. If \code{NULL}, uses stored value.}
 
-\item{\code{store_backends}}{(logical(1)) Whether to store backends}
+\item{\code{store_backends}}{(logical(1)) Whether to store backends, passed to \code{\link[mlr3:resample]{mlr3::resample()}} internally
+for the initial fit of the learner.
+This may be required for certain measures and is recommended to leave enabled unless really necessary.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/SAGE.Rd
+++ b/man/SAGE.Rd
@@ -64,8 +64,10 @@ In \emph{Advances in Neural Information Processing Systems}, volume 33, 17212--1
 <details open><summary>Inherited methods</summary>
 <ul>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="importance"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-importance'><code>xplainfi::FeatureImportanceMethod$importance()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="obs_scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-obs_scores'><code>xplainfi::FeatureImportanceMethod$obs_scores()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="print"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-print'><code>xplainfi::FeatureImportanceMethod$print()</code></a></span></li>
 <li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="reset"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-reset'><code>xplainfi::FeatureImportanceMethod$reset()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="xplainfi" data-topic="FeatureImportanceMethod" data-id="scores"><a href='../../xplainfi/html/FeatureImportanceMethod.html#method-FeatureImportanceMethod-scores'><code>xplainfi::FeatureImportanceMethod$scores()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/vignettes/articles/perturbation-importance.Rmd
+++ b/vignettes/articles/perturbation-importance.Rmd
@@ -108,8 +108,8 @@ pfi_int <- PFI$new(
 )
 
 # Compute importance scores
-pfi_int$compute(relation = "difference")
-pfi_int$importance()
+pfi_int$compute()
+pfi_int$importance(relation = "difference")
 ```
 
 Expected: x1 and x2 will show high importance with PFI because permuting either feature destroys the interaction term x1×x2, which is crucial for prediction. This demonstrates a key limitation of PFI with interactions.
@@ -133,8 +133,8 @@ cfi_int <- CFI$new(
 )
 
 # Compute importance scores
-cfi_int$compute(relation = "difference")
-cfi_int$importance()
+cfi_int$compute()
+cfi_int$importance(relation = "difference")
 ```
 
 Expected: CFI should show somewhat lower importance for x1 and x2 compared to PFI because it better preserves the interaction structure during conditional sampling, providing a more nuanced importance estimate.
@@ -155,7 +155,7 @@ rfi_int_x2 <- RFI$new(
 	iters_perm = 5,
 	sampler = sampler_int
 )
-rfi_int_x2$compute(relation = "difference")
+rfi_int_x2$compute()
 
 # RFI conditioning on x1: "How important is x2 given we know x1?"
 rfi_int_x1 <- RFI$new(
@@ -167,7 +167,7 @@ rfi_int_x1 <- RFI$new(
 	iters_perm = 5,
 	sampler = sampler_int
 )
-rfi_int_x1$compute(relation = "difference")
+rfi_int_x1$compute()
 ```
 
 **RFI Results:**
@@ -358,7 +358,7 @@ pfi_conf <- PFI$new(
 	iters_perm = 5
 )
 
-pfi_conf$compute(relation = "difference")
+pfi_conf$compute()
 pfi_conf$importance()
 ```
 
@@ -386,7 +386,7 @@ rfi_conf <- RFI$new(
 	sampler = sampler_conf
 )
 
-rfi_conf$compute(relation = "difference")
+rfi_conf$compute()
 rfi_conf$importance()
 ```
 
@@ -403,7 +403,7 @@ cfi_conf <- CFI$new(
 	sampler = sampler_conf
 )
 
-cfi_conf$compute(relation = "difference")
+cfi_conf$compute()
 cfi_conf$importance()
 ```
 
@@ -434,7 +434,8 @@ rfi_conf_obs <- RFI$new(
 	sampler = sampler_conf_obs
 )
 
-rfi_conf_obs$compute(relation = "difference")
+rfi_conf_obs$compute()
+rfi_conf_obs$importance()
 
 # Compare with PFI on the same data
 pfi_conf_obs <- PFI$new(
@@ -444,7 +445,8 @@ pfi_conf_obs <- PFI$new(
 	resampling = resampling,
 	iters_perm = 5
 )
-pfi_conf_obs$compute(relation = "difference")
+pfi_conf_obs$compute()
+pfi_conf_obs$importance()
 ```
 
 **Key Results:**
@@ -588,7 +590,7 @@ pfi_cor <- PFI$new(
 	iters_perm = 5
 )
 
-pfi_cor$compute(relation = "difference")
+pfi_cor$compute()
 pfi_cor$importance()
 ```
 
@@ -610,7 +612,7 @@ cfi_cor <- CFI$new(
 	sampler = sampler_cor
 )
 
-cfi_cor$compute(relation = "difference")
+cfi_cor$compute()
 cfi_cor$importance()
 ```
 
@@ -630,7 +632,7 @@ rfi_cor_x1 <- RFI$new(
 	iters_perm = 5,
 	sampler = sampler_cor
 )
-rfi_cor_x1$compute(relation = "difference")
+rfi_cor_x1$compute()
 
 # RFI conditioning on x2: "How important is x1 given we know x2?"
 rfi_cor_x2 <- RFI$new(
@@ -642,7 +644,7 @@ rfi_cor_x2 <- RFI$new(
 	iters_perm = 5,
 	sampler = sampler_cor
 )
-rfi_cor_x2$compute(relation = "difference")
+rfi_cor_x2$compute()
 ```
 
 **RFI Results:**
@@ -768,7 +770,7 @@ pfi_ind <- PFI$new(
 	resampling = resampling,
 	iters_perm = 5
 )
-pfi_ind$compute(relation = "difference")
+pfi_ind$compute()
 ```
 
 Now CFI  with the ARF sampler:
@@ -784,7 +786,7 @@ cfi_ind <- CFI$new(
 	iters_perm = 5,
 	sampler = sampler_ind
 )
-cfi_ind$compute(relation = "difference")
+cfi_ind$compute()
 ```
 
 RFI with empty conditioning set, basically equivalent to PFI with a different sampler:
@@ -800,7 +802,7 @@ rfi_ind <- RFI$new(
 	iters_perm = 5,
 	sampler = sampler_ind
 )
-rfi_ind$compute(relation = "difference")
+rfi_ind$compute()
 ```
 
 And now we visualize:
@@ -924,7 +926,7 @@ ggplot(var_comparison, aes(x = feature, y = importance, color = method)) +
 	) +
 	labs(
 		title = "Corrected vs Uncorrected Confidence Intervals",
-		subtitle = "Nadeau-Bengio correction provides honest uncertainty estimates",
+		subtitle = "Nadeau-Bengio correction provides more honest uncertainty estimates",
 		y = "Importance Score",
 		x = NULL,
 		color = NULL

--- a/vignettes/xplainfi.Rmd
+++ b/vignettes/xplainfi.Rmd
@@ -94,14 +94,12 @@ pfi_stable$compute()
 pfi_stable$importance()
 ```
 
-We can also use ratio instead of difference for the importance calculation:
+We can also use ratio instead of difference for the importance calculation, meaning that an unimportant feature is now expected to get an importance score of 1 rather than 0:
 
 ```{r pfi-ratio}
-pfi_stable$compute(relation = "ratio")
-pfi_stable$importance()
+pfi_stable$importance(relation = "ratio")
 ```
 
-**Note**: This API will most likely change in an upcoming version to enable changing the `"ratio"` without having to re-compute everything.
 
 ## Leave-One-Covariate-Out (LOCO)
 
@@ -165,14 +163,14 @@ xplainfi supports many advanced features for robust importance estimation:
 All methods store detailed scoring information for further analysis. Let's examine the structure of PFI's detailed scores:
 
 ```{r detailed-scores}
-head(pfi$scores, 10) |>
+head(pfi$scores(), 10) |>
 	knitr::kable(digits = 4, caption = "Detailed PFI scores (first 10 rows)")
 ```
 
 We can also summarize the scoring structure:
 
 ```{r scoring-summary}
-pfi$scores[, .(
+pfi$scores()[, .(
 	features = uniqueN(feature),
 	resampling_folds = uniqueN(iter_rsmp),
 	permutation_iters = uniqueN(iter_perm),


### PR DESCRIPTION
Introduces new public methods and private fields

- `$obs_scores()` computes observation-wise importance scores(?) based on stored obs losses
- `$scores()` computes importances for resampling and (e.g.) permutation iteration based on stored scores
- `$importance()` computes importances now based on `$scores()`

Each will use the chosen `relation`, e.g. `difference` or `ratio`, so this also allows changing the relation of interest on the fly without having to recompute anything expensive.

This change of handling `obs_loss` stuff will need to be reflected when `LeaveOutIn` is refactored, and to avoid a huuuge PR I'm choosing to leave other parts of the package in a partially broken state (at least in terms of unit tests..)


``` r
library(xplainfi)
library(mlr3learners)
#> Loading required package: mlr3
set.seed(123)

learner <- lrn("regr.ranger", num.trees = 100)
resampling <- rsmp("subsampling", repeats = 3)
measure <- msr("regr.mse")

task_int <- sim_dgp_interactions(n = 1000)

pfi <- PFI$new(
    task = task_int,
    learner = learner,
    measure = measure,
    resampling = resampling,
    iters_perm = 5
)
# Compute what is needed only
pfi$compute()

# On the fly based on stored losses
head(pfi$obs_scores())
#>    feature iter_rsmp iter_perm row_ids baseline_loss loss_perturbed
#>     <char>     <int>     <int>   <int>         <num>          <num>
#> 1:  noise1         1         1       6    1.40592709     2.25558622
#> 2:  noise1         1         1      10    0.01445415     0.01151480
#> 3:  noise1         1         1      12   17.17004496    14.59310409
#> 4:  noise1         1         1      19    0.87735654     0.77311852
#> 5:  noise1         1         1      20    3.33947915     3.33947915
#> 6:  noise1         1         1      22    0.01845980     0.02505642

# on the fly based on stored scores
head(pfi$scores())
#>    feature iter_rsmp iter_perm regr.mse_baseline regr.mse_perturbed  importance
#>     <char>     <int>     <int>             <num>              <num>       <num>
#> 1:  noise1         1         1          3.439843           3.381053 -0.05879041
#> 2:  noise2         1         1          3.439843           3.471720  0.03187633
#> 3:      x1         1         1          3.439843           5.426523  1.98667992
#> 4:      x2         1         1          3.439843           5.519902  2.08005825
#> 5:      x3         1         1          3.439843           5.291778  1.85193426
#> 6:  noise1         1         2          3.439843           3.412475 -0.02736817

# on the fly based on $scores()
pfi$importance()
#> Key: <feature>
#>    feature  importance
#>     <char>       <num>
#> 1:  noise1 0.002159862
#> 2:  noise2 0.045822165
#> 3:      x1 2.651433746
#> 4:      x2 2.344620690
#> 5:      x3 2.067656949
```

<sup>Created on 2025-09-30 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
