### PR TITLE
Fix `obs_loss()` usage without measure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xplainfi
 Title: Feature Importance Methods for Global Explanations
-Version: 1.1.0
+Version: 1.1.0.9000
 Authors@R: 
     person("Lukas", "Burk", , "cran@lukasburk.de", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0001-7528-3795"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# xplainfi 1.1.0.9000 (development version)
+
+- Fix `$obs_loss()` being erroneously called without `measure` in `PerturbationImportance`, resulting in an error when `measures` was not the task-default.
+
 # xplainfi 1.1.0
 
 ## New features

--- a/R/PerturbationImportance.R
+++ b/R/PerturbationImportance.R
@@ -316,7 +316,7 @@ PerturbationImportance = R6Class(
 						pred <- prediction[[1]]
 
 						# Get only vector of obs losses, Prediction$obs_loss() returns full table
-						obs_loss_vals <- pred$obs_loss()[[self$measure$id]]
+						obs_loss_vals <- pred$obs_loss(measures = self$measure)[[self$measure$id]]
 
 						list(
 							row_ids = pred$row_ids,

--- a/man/FeatureImportanceMethod.Rd
+++ b/man/FeatureImportanceMethod.Rd
@@ -14,7 +14,8 @@ Nadeau C, Bengio Y (2003).
 Molnar C, Freiesleben T, König G, Herbinger J, Reisinger T, Casalicchio G, Wright M, Bischl B (2023).
 \dQuote{Relating the Partial Dependence Plot and Permutation Feature Importance to the Data Generating Process.}
 In Longo L (ed.), \emph{Explainable Artificial Intelligence}, 456--479.
-ISBN 978-3-031-44064-9, \doi{10.1007/978-3-031-44064-9_24}.
+ISBN 978-3-031-44064-9.
+\doi{10.1007/978-3-031-44064-9_24}.
 }
 \section{Public fields}{
   \if{html}{\out{<div class="r6-fields">}}

--- a/man/sim_dgp_ewald.Rd
+++ b/man/sim_dgp_ewald.Rd
@@ -39,7 +39,8 @@ sim_dgp_ewald(100)
 Ewald F, Bothmann L, Wright M, Bischl B, Casalicchio G, König G (2024).
 \dQuote{A Guide to Feature Importance Methods for Scientific Inference.}
 In Longo L, Lapuschkin S, Seifert C (eds.), \emph{Explainable Artificial Intelligence}, 440--464.
-ISBN 978-3-031-63797-1, \doi{10.1007/978-3-031-63797-1_22}.
+ISBN 978-3-031-63797-1.
+\doi{10.1007/978-3-031-63797-1_22}.
 }
 \seealso{
 Other simulation:

--- a/man/sim_dgp_scenarios.Rd
+++ b/man/sim_dgp_scenarios.Rd
@@ -189,7 +189,8 @@ task$data()
 Ewald F, Bothmann L, Wright M, Bischl B, Casalicchio G, König G (2024).
 \dQuote{A Guide to Feature Importance Methods for Scientific Inference.}
 In Longo L, Lapuschkin S, Seifert C (eds.), \emph{Explainable Artificial Intelligence}, 440--464.
-ISBN 978-3-031-63797-1, \doi{10.1007/978-3-031-63797-1_22}.
+ISBN 978-3-031-63797-1.
+\doi{10.1007/978-3-031-63797-1_22}.
 }
 \seealso{
 Other simulation:

--- a/tests/testthat/test-PFI.R
+++ b/tests/testthat/test-PFI.R
@@ -142,3 +142,35 @@ test_that("PFI scores and obs_losses agree", {
 
 	expect_equal(importance_scores, obs_agg, tolerance = sqrt(.Machine$double.eps))
 })
+
+test_that("PFI obs_loss uses specified measure, not default", {
+	# Regression test for bug where pred$obs_loss() was called without
+	# passing the measure, causing it to use the default measure (regr.mse)
+	# instead of the user-specified one. With a non-default measure like
+	# regr.mae, this caused obs_loss values to be NULL/wrong.
+	task = mlr3::tsk("mtcars")
+
+	pfi = PFI$new(
+		task = task,
+		learner = lrn("regr.rpart"),
+		measure = msr("regr.mae"),
+		n_repeats = 1L
+	)
+
+	pfi$compute()
+
+	obs_losses = pfi$obs_loss()
+	expect_obs_loss_dt(obs_losses, features = task$feature_names)
+
+	# obs_loss values should be absolute errors (MAE), not squared errors (MSE).
+	# Verify by checking that aggregating obs losses matches the score-level
+	# importance (which correctly uses the specified measure).
+	scores = pfi$scores()[, .(iter_rsmp, feature, importance)][order(iter_rsmp, feature)]
+
+	obs_agg = obs_losses[,
+		list(importance = mean(obs_importance)),
+		by = c("iter_rsmp", "feature")
+	][order(iter_rsmp, feature)]
+
+	expect_equal(scores, obs_agg, tolerance = sqrt(.Machine$double.eps))
+})


### PR DESCRIPTION
This fixes a bug that came up when the `measure` was different than the task's default measure in `PerturbationImportance`, where `$obs_loss()` was called without argument.

