### PR TITLE
`ConditionalSAGE` uses `samples_per_row` as well

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,12 @@
   - Worker count per daemon is controlled by the new `arf_workers` option (default `2L`);
     see `?xplain_opt`.
   - Requires the `doParallel` package (now in Suggests).
+- `ConditionalSAGE` now passes `samples_per_row = n_samples` to the sampler on unique
+  test rows, instead of replicating test rows externally before calling the sampler.
+  - For `ConditionalARFSampler` this triggers the same `arf::forge(n_synth = n_samples)`
+    speedup as `PerturbationImportance`, on `n_test` unique evidence rows rather than
+    `n_samples * n_test` replicated rows.
+  - Marginal SAGE (`MarginalSAGE`) does not use a `FeatureSampler` and is unaffected.
 
 ## Bug fixes
 
@@ -27,6 +33,19 @@
   resulting in an error when `measures` was not the task-default.
 - `ConditionalARFSampler$sample()` now errors when `parallel = TRUE` but no parallel backend
   is registered, e.g. after deserializing a sampler in a new session.
+- Fix `ConditionalARFSampler` returning under-sampled (and, with `samples_per_row > 1`,
+  partially `NA`-filled) outputs when `conditioning_set` is empty.
+  - `arf::forge(evidence = NULL, n_synth = k)` returns only `k` unconditional draws,
+    not `nrow(data) * k`; the previous code path silently recycled a single sample
+    across all output rows when `samples_per_row = 1L`.
+  - The marginal case now requests `nrow(data) * samples_per_row` independent
+    unconditional draws so every (instance, draw) pair gets its own sample.
+  - In practice this only affects `ConditionalSAGE` (which calls the sampler with an
+    empty conditioning set on every empty coalition); CFI/RFI/PFI condition on the
+    complement of the perturbed feature and never trigger the empty-conditioning path.
+  - As a side effect, `ConditionalSAGE` importance estimates for noise features are
+    now substantially less inflated under the same `n_permutations` / `n_samples`
+    budget.
 
 ## Internal changes
 

--- a/R/ConditionalARFSampler.R
+++ b/R/ConditionalARFSampler.R
@@ -236,45 +236,62 @@ ConditionalARFSampler = R6Class(
 				))
 			}
 
+			n = nrow(data)
+
 			if (length(conditioning_set) == 0) {
 				if (xplain_opt("debug")) {
 					cli::cli_alert_info(
 						"{.val conditioning_set} is length 0, passing {.code evidence = NULL} to {.fun arf::forge}"
 					)
 				}
-				evidence = NULL
+
+				# Marginal case: arf::forge(evidence = NULL, n_synth = k) returns only k rows
+				# (k unconditional draws), not n * k. We need n * samples_per_row independent
+				# marginal draws so every (instance, draw) pair gets its own sample, so request
+				# the full count up front; no reshape needed since marginal draws are
+				# exchangeable across instances.
+				synthetic = arf::forge(
+					params = self$psi,
+					n_synth = n * samples_per_row,
+					evidence = NULL,
+					evidence_row_mode = "separate",
+					round = round,
+					sample_NAs = FALSE,
+					nomatch = "force",
+					verbose = verbose,
+					stepsize = stepsize,
+					parallel = parallel
+				)
 			} else {
 				evidence = data[, .SD, .SDcols = conditioning_set]
-			}
 
-			if (xplain_opt("debug")) {
-				cli::cli_inform(c(
-					i = "Feature is {.val {feature}}",
-					i = "Conditioning set is {.val {conditioning_set}}",
-					i = "samples_per_row = {.val {samples_per_row}}"
-				))
-			}
+				if (xplain_opt("debug")) {
+					cli::cli_inform(c(
+						i = "Feature is {.val {feature}}",
+						i = "Conditioning set is {.val {conditioning_set}}",
+						i = "samples_per_row = {.val {samples_per_row}}"
+					))
+				}
 
-			synthetic = arf::forge(
-				params = self$psi,
-				n_synth = samples_per_row,
-				evidence = evidence,
-				evidence_row_mode = "separate",
-				round = round,
-				sample_NAs = FALSE,
-				nomatch = "force",
-				verbose = verbose,
-				stepsize = stepsize,
-				parallel = parallel
-			)
+				synthetic = arf::forge(
+					params = self$psi,
+					n_synth = samples_per_row,
+					evidence = evidence,
+					evidence_row_mode = "separate",
+					round = round,
+					sample_NAs = FALSE,
+					nomatch = "force",
+					verbose = verbose,
+					stepsize = stepsize,
+					parallel = parallel
+				)
 
-			n = nrow(data)
-
-			if (samples_per_row > 1L) {
-				# arf returns evidence-major: e1d1, e1d2, ..., e1dk, e2d1, ..., endk
-				# we want draw-major: e1d1, e2d1, ..., end1, e1d2, ..., endk
-				draw_idx = ((seq_len(n * samples_per_row) - 1L) %% samples_per_row) + 1L
-				synthetic = synthetic[order(draw_idx)]
+				if (samples_per_row > 1L) {
+					# arf returns evidence-major: e1d1, e1d2, ..., e1dk, e2d1, ..., endk
+					# we want draw-major: e1d1, e2d1, ..., end1, e1d2, ..., endk
+					draw_idx = ((seq_len(n * samples_per_row) - 1L) %% samples_per_row) + 1L
+					synthetic = synthetic[order(draw_idx)]
+				}
 			}
 
 			out = data[rep.int(seq_len(.N), times = samples_per_row)]

--- a/R/SAGE-conditional.R
+++ b/R/SAGE-conditional.R
@@ -110,29 +110,28 @@ ConditionalSAGE = R6Class(
 				marginalize_features = setdiff(self$features, coalition)
 
 				if (length(marginalize_features) > 0) {
-					# Expand test data to sample multiple times for averaging
-					# Each test instance is replicated n_samples times
-					test_dt_expanded = test_dt[rep(
-						seq_len(n_test),
-						each = self$param_set$values$n_samples
-					)]
+					n_samples = self$param_set$values$n_samples
 
-					# Sample conditionally using a sampler
+					# Sample conditionally using a sampler. Pass `samples_per_row = n_samples`
+					# on the unique test rows so the sampler can use its native efficient
+					# multi-draw path (e.g. ConditionalARFSampler invokes
+					# `arf::forge(n_synth = n_samples)` on n_test evidence rows rather than
+					# n_samples * n_test replicated rows).
 					# Returns test_dt with "marginalized" features replaced by conditional samples
 					# sampler: P(marginalize_features | coalition_features)
 					marginalized_test = self$sampler$sample_newdata(
 						feature = marginalize_features,
-						newdata = test_dt_expanded,
-						conditioning_set = coalition
+						newdata = test_dt,
+						conditioning_set = coalition,
+						samples_per_row = n_samples
 					)
 
-					# Add test instance ID for tracking which original test instance each row belongs to
-					# Must be done AFTER sampling since sampler does not preserve extra columns
+					# Tag rows with their originating test instance. Sampler output is
+					# draw-major: rows 1..n_test = draw 1 across all test rows in order,
+					# rows n_test+1..2*n_test = draw 2, etc. Hence `times`, not `each`.
+					# Must be done AFTER sampling since sampler does not preserve extra columns.
 					marginalized_test[,
-						.test_instance_id := rep(
-							seq_len(n_test),
-							each = self$param_set$values$n_samples
-						)
+						.test_instance_id := rep(seq_len(n_test), times = n_samples)
 					]
 				} else {
 					# If marginalize_features is empty then we evaluate the coalition of all features

--- a/tests/testthat/test-ConditionalSAGE.R
+++ b/tests/testthat/test-ConditionalSAGE.R
@@ -294,3 +294,56 @@ test_that("ConditionalSAGE SE tracking in convergence_history", {
 		sage$features
 	)
 })
+
+# -----------------------------------------------------------------------------
+# Regression guard for the samples_per_row migration (+ underlying ARF fix)
+# -----------------------------------------------------------------------------
+
+test_that("ConditionalSAGE noise feature receives ~0 importance with ARFSampler", {
+	skip_if_not_installed("arf")
+	skip_if_not_installed("ranger")
+	skip_if_not_installed("mlr3learners")
+
+	# `sim_dgp_correlated`: y = 2 * x1 + x3 + noise; x1 correlated with x2 (r),
+	# x4 is pure noise (independent, no causal effect). The expected SAGE pattern:
+	#   - x1 dominant (signal, coef 2)
+	#   - x3 next (signal, coef 1)
+	#   - x2 some attribution via Shapley (correlated with x1 but no causal effect)
+	#   - x4 ~ 0 (pure noise)
+	#
+	# A regression in the multi-draw conditional sampling path tends to inflate
+	# all SAGE values (notably for x4) because empty-coalition predictions become
+	# garbage. This test pins both the signal/noise pattern and concrete values
+	# captured on the post-fix branch.
+	set.seed(42L)
+	task = sim_dgp_correlated(n = 200L, r = 0.7)
+	sage = ConditionalSAGE$new(
+		task = task,
+		learner = lrn("regr.ranger", num.trees = 100L),
+		measure = msr("regr.mse"),
+		sampler = ConditionalARFSampler$new(task, verbose = FALSE),
+		n_permutations = 30L,
+		n_samples = 30L
+	)
+	sage$compute()
+	imp = sage$importance()
+
+	# Correctness: noise feature x4 stays near zero, signal features dominate.
+	expect_lt(abs(imp[feature == "x4", importance]), 0.3)
+	expect_gt(imp[feature == "x1", importance], 0.5)
+	expect_gt(imp[feature == "x1", importance], imp[feature == "x4", importance] + 1.0)
+
+	# Regression guard. Captured on the post-fix branch at the same settings.
+	# Tolerance generous enough to absorb run-to-run MC variation under different
+	# R / arf / ranger versions; if it ever breaks, regenerate by running the same
+	# block and pasting `imp$importance` below.
+	expected_features = c("x1", "x2", "x3", "x4")
+	expected_importance = c(
+		 1.75718693344525,
+		 0.359611168661264,
+		 0.651142439812633,
+		-0.0157528350794578
+	)
+	expect_equal(imp$feature, expected_features)
+	expect_equal(imp$importance, expected_importance, tolerance = 0.5)
+})


### PR DESCRIPTION
Same as #78 but for cSAGE.

Also includes a leftover bug fix where the arf sampler returns the wrong number of rows for `evidence = NULL` and `samplers_per_row` > 1, which only affects cSAGE rather than CFI